### PR TITLE
Add navigation sorting option

### DIFF
--- a/src/services/AppStore.ts
+++ b/src/services/AppStore.ts
@@ -81,7 +81,7 @@ export class AppStore {
     MenuStore.updateOnHistory(history.currentId, this.scroll);
 
     this.spec = new SpecStore(spec, specUrl, this.options);
-    this.menu = new MenuStore(this.spec, this.scroll, history);
+    this.menu = new MenuStore(this.spec, this.scroll, history, this.options);
 
     if (!this.options.disableSearch) {
       this.search = new SearchStore();

--- a/src/services/MenuStore.ts
+++ b/src/services/MenuStore.ts
@@ -7,6 +7,7 @@ import { ScrollService } from './ScrollService';
 
 import { flattenByProp, SECURITY_SCHEMES_SECTION_PREFIX } from '../utils';
 import { GROUP_DEPTH } from './MenuBuilder';
+import { RedocNormalizedOptions } from './RedocNormalizedOptions';
 
 export type MenuItemGroupType = 'group' | 'tag' | 'section';
 export type MenuItemType = MenuItemGroupType | 'operation';
@@ -75,12 +76,19 @@ export class MenuStore {
    * @param spec [SpecStore](#SpecStore) which contains page content structure
    * @param scroll scroll service instance used by this menu
    */
-  constructor(spec: SpecStore, public scroll: ScrollService, public history: HistoryService) {
+  constructor(spec: SpecStore, public scroll: ScrollService, public history: HistoryService, public options: RedocNormalizedOptions) {
     makeObservable(this);
 
     this.items = spec.contentItems;
 
     this.flatItems = flattenByProp(this.items || [], 'items');
+    if (this.options.sortNavigationPathsAlphabetically) {
+      this.flatItems.map(item => {
+        if (item.type === "tag") {
+          item.items.sort((a, b) => a.name > b.name ? 1 : -1);
+        }
+      });
+    }
     this.flatItems.forEach((item, idx) => (item.absoluteIdx = idx));
 
     this.subscribe();

--- a/src/services/RedocNormalizedOptions.ts
+++ b/src/services/RedocNormalizedOptions.ts
@@ -13,6 +13,7 @@ export interface RedocRawOptions {
   requiredPropsFirst?: boolean | string;
   sortPropsAlphabetically?: boolean | string;
   sortEnumValuesAlphabetically?: boolean | string;
+  sortNavigationPathsAlphabetically?: boolean | string;
   noAutoAuth?: boolean | string;
   nativeScrollbars?: boolean | string;
   pathInMiddlePanel?: boolean | string;
@@ -170,6 +171,7 @@ export class RedocNormalizedOptions {
   requiredPropsFirst: boolean;
   sortPropsAlphabetically: boolean;
   sortEnumValuesAlphabetically: boolean;
+  sortNavigationPathsAlphabetically: boolean;
   noAutoAuth: boolean;
   nativeScrollbars: boolean;
   pathInMiddlePanel: boolean;
@@ -227,6 +229,7 @@ export class RedocNormalizedOptions {
     this.requiredPropsFirst = argValueToBoolean(raw.requiredPropsFirst);
     this.sortPropsAlphabetically = argValueToBoolean(raw.sortPropsAlphabetically);
     this.sortEnumValuesAlphabetically = argValueToBoolean(raw.sortEnumValuesAlphabetically);
+    this.sortNavigationPathsAlphabetically = argValueToBoolean(raw.sortNavigationPathsAlphabetically);
     this.noAutoAuth = argValueToBoolean(raw.noAutoAuth);
     this.nativeScrollbars = argValueToBoolean(raw.nativeScrollbars);
     this.pathInMiddlePanel = argValueToBoolean(raw.pathInMiddlePanel);


### PR DESCRIPTION
Currently tags are sorted by the order from schema file. However, path objects under each tag is not sorted.

Add `sortNavigationPathsAlphabetically` option.

More details in https://github.com/Redocly/redoc/issues/98